### PR TITLE
[Ppamppam] fe-w3-shopping 4일차 작업

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -7,7 +7,7 @@ import { default as apiRoutes } from "./apiRoutes.js";
 
 const app = express();
 const port = 3333;
-// app.use(cors());
+app.use(cors());
 
 app.get('/', (req, res) => {
   res.send('Hello World!');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,12 +1,13 @@
 import HeaderPresentational from "./src/components/Header/HeaderPresentational.js"
 
-import "./app.sass.scss";
+import "./app.scss";
 
 class App {
   constructor({ $target }) {
     this.$target = $target;
     this.header = null;
   }
+  
   init() {
     let $target = null;
     

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,11 +1,15 @@
 import HeaderPresentational from "./src/components/Header/HeaderPresentational.js"
+import BannerContainer from "./src/components/Banner/BannerContainer.js";
 
 import "./app.scss";
 
 class App {
   constructor({ $target }) {
     this.$target = $target;
+    
+    // SPA areas
     this.header = null;
+    this.banner = null;
   }
   
   init() {
@@ -14,6 +18,8 @@ class App {
     $target = this.$target.querySelector("div#header");
     this.header = new HeaderPresentational({ $target });
     
+    $target = this.$target.querySelector("div#banner");
+    this.banner = new BannerContainer({ $target });
   }
 }
 

--- a/frontend/app.scss
+++ b/frontend/app.scss
@@ -1,5 +1,3 @@
-// global
-
 // reset.css
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
@@ -22,10 +20,16 @@ time, mark, audio, video {
 	vertical-align: baseline;
 }
 
+// global used
+
 ul {
   list-style: none;
 }
 
 .container {
   margin: 0 auto;
+}
+
+.main {
+  background-color: #f3f3f3;
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,7 +7,7 @@
       <div id="header"></div>
 
       <div class="main">
-        <div id="banner" class="banner"></div>
+        <div id="banner"></div>
         <div id="items"></div>
         <div id="hot-theme-category"></div>
       </div>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,7 +7,7 @@
       <div id="header"></div>
 
       <div class="main">
-        <div id="banner"></div>
+        <div id="banner" class="banner"></div>
         <div id="items"></div>
         <div id="hot-theme-category"></div>
       </div>

--- a/frontend/src/components/Banner/BannerContainer.js
+++ b/frontend/src/components/Banner/BannerContainer.js
@@ -7,13 +7,18 @@ class BannerContainer {
   constructor({ $target }) {
     this.$target = $target;
     this.$BannerPresentational = null;
-
-    // for caching
-    this.$cached = {};
+    this.$BannerCarousel = document.createElement("div");
+    this.$BannerCarousel.class = "banner-carousel";
+    
+    this.$cached = {}; // for caching DOM
 
     // 상태
     this.fixedImage = "";
-  
+    this.bannerCarouselContainer = null;
+    
+    // let $target = this.$BannerPresentational.$target.querySelector("#banner-slide");
+    // new BannerCarouselContainer({ $target: this.$BannerCarousel, carouselImages: data.mileageList });
+
     this.init();
   }
 
@@ -38,10 +43,7 @@ class BannerContainer {
 
   // 최적화 영역
   isMemorable(nextProp) {
-    if (!this.$cached.hasOwnProperty(nextProp)) {
-      return true;
-    }
-    return false;
+    return !this.$cached.hasOwnProperty(nextProp) ? true : false;
   }
 
   isCacheHit(prop) {
@@ -54,13 +56,10 @@ class BannerContainer {
 
 
   render() { 
-    if (this.$BannerPresentational === null) { // initial render
+    if (this.$BannerPresentational === null || this.isMemorable(this.fixedImage)) {
       this.$BannerPresentational = new BannerPresentational({ $target: this.$target, fixedImage: this.fixedImage });
-    }
-    else if (this.isMemorable(this.fixedImage)) {  // cache not hit 
-      this.$BannerPresentational = new BannerPresentational({ $target: this.$target, fixedImage: this.fixedImage });
-    }
-    else { // cache hit
+      // this.$BannerPresentational.$Banner.querySelector("#banner-carousel").appendChild(this.$BannerCarousel); // 배너 캐로셀 추가 예정
+    } else { // cache hit
       this.$BannerPresentational = this.isCacheHit(this.fixedImage);
       this.$target.innerHTML = "";
       this.$BannerPresentational.reRender();

--- a/frontend/src/components/Banner/BannerContainer.js
+++ b/frontend/src/components/Banner/BannerContainer.js
@@ -1,0 +1,14 @@
+import BannerPresentational from './BannerPresentational.js';
+import BannerCarouselContainer from './BannerCarouselContainer.js';
+
+class BannerContainer {
+  constructor({ $target }) {
+    this.$BannerPresentational = new BannerPresentational({ $target });
+    
+    // 배너 캐로셀 initialize
+    // let $target = this.$target.querySelector("#banner-slide");
+    // this.bannerCarouselContainer = new BannerCarouselContainer({ $target, state });
+  }
+}
+
+export default BannerContainer;

--- a/frontend/src/components/Banner/BannerContainer.js
+++ b/frontend/src/components/Banner/BannerContainer.js
@@ -6,45 +6,53 @@ import API from "../../util/api.js"; // root를 alias하는 방법을 찾아보�
 class BannerContainer {
   constructor({ $target }) {
     this.$target = $target;
-    this.$BannerPresentational = new BannerPresentational({ $target });
+    this.$BannerPresentational = null;
     
-    this.fixedImages = "";
-    this.carouselImages = [];
+    this.fixedImage = "";
+    
     // 배너 캐로셀 initialize
+    // this.carouselImages = [];
     // let $target = this.$BannerPresentational.$target.querySelector("#banner-slide");
     // this.bannerCarouselContainer = new BannerCarouselContainer({ $target, state });
+    // console.log(data.mallEventList.slice(0,10));
+    // carouselImages: data.mileageList
+
+    this.init();
   }
 
   init() {
     this.resetState();
-    // API에서 받아 옴.
-    API.get.banner((response) => {
-      // 받아와서
-      this.setState(response);
+    
+    API.get.bannerInfo().then((data) => {
+      this.setState({ 
+        fixedImage: data.event.imgurl
+      });
     });
   }
   
-  setState({ fixedImages, carouselImages }) {
-    if (this.fixedImages !== "" || this.carouselImages.length !== 0 ) {
+  setState({ fixedImage }) {
+    if (this.fixedImage !== "") {
       this.resetState();  
     }
-    this.setFixedImages(fixedImages);
-    this.setCarouselImages(carouselImages);
+    this.setFixedImages(fixedImage);
+    this.render();
   }
 
   resetState() {
-    this.fixedImages = "";
-    this.carouselImages = [];
+    this.fixedImage = "";
   }
 
-  setFixedImages(fixedImages) {
-    this.fixedImages = fixedImages;
+  setFixedImages(fixedImage) {
+    this.fixedImage = fixedImage;
   }
 
-  setCarouselImages(carouselImages) {
-    this.carouselImages = carouselImages;
-  }
+  // setCarouselImages(carouselImages) {
+  //   this.carouselImages = carouselImages;
+  // }
 
+  render() {
+    this.$BannerPresentational = new BannerPresentational({ $target: this.$target, fixedImage: this.fixedImage });
+  }
 }
 
 export default BannerContainer;

--- a/frontend/src/components/Banner/BannerContainer.js
+++ b/frontend/src/components/Banner/BannerContainer.js
@@ -1,12 +1,13 @@
 import BannerPresentational from './BannerPresentational.js';
-import BannerCarouselContainer from './BannerCarouselContainer.js';
+// import BannerCarouselContainer from './BannerCarouselContainer.js';
 
 class BannerContainer {
   constructor({ $target }) {
+    this.$target = $target;
     this.$BannerPresentational = new BannerPresentational({ $target });
     
     // 배너 캐로셀 initialize
-    // let $target = this.$target.querySelector("#banner-slide");
+    // let $target = this.$BannerPresentational.$target.querySelector("#banner-slide");
     // this.bannerCarouselContainer = new BannerCarouselContainer({ $target, state });
   }
 }

--- a/frontend/src/components/Banner/BannerContainer.js
+++ b/frontend/src/components/Banner/BannerContainer.js
@@ -13,16 +13,8 @@ class BannerContainer {
 
     // 상태
     this.fixedImage = "";
-    
-    // 배너 캐로셀 initialize
-    // this.carouselImages = [];
-    // let $target = this.$BannerPresentational.$target.querySelector("#banner-slide");
-    // this.bannerCarouselContainer = new BannerCarouselContainer({ $target, state });
-    // console.log(data.mallEventList.slice(0,10));
-    // carouselImages: data.mileageList
-
+  
     this.init();
-    window.bc = this;
   }
 
   init() {

--- a/frontend/src/components/Banner/BannerContainer.js
+++ b/frontend/src/components/Banner/BannerContainer.js
@@ -1,15 +1,50 @@
 import BannerPresentational from './BannerPresentational.js';
 // import BannerCarouselContainer from './BannerCarouselContainer.js';
 
+import API from "../../util/api.js"; // root를 alias하는 방법을 찾아보는 중입니다.
+
 class BannerContainer {
   constructor({ $target }) {
     this.$target = $target;
     this.$BannerPresentational = new BannerPresentational({ $target });
     
+    this.fixedImages = "";
+    this.carouselImages = [];
     // 배너 캐로셀 initialize
     // let $target = this.$BannerPresentational.$target.querySelector("#banner-slide");
     // this.bannerCarouselContainer = new BannerCarouselContainer({ $target, state });
   }
+
+  init() {
+    this.resetState();
+    // API에서 받아 옴.
+    API.get.banner((response) => {
+      // 받아와서
+      this.setState(response);
+    });
+  }
+  
+  setState({ fixedImages, carouselImages }) {
+    if (this.fixedImages !== "" || this.carouselImages.length !== 0 ) {
+      this.resetState();  
+    }
+    this.setFixedImages(fixedImages);
+    this.setCarouselImages(carouselImages);
+  }
+
+  resetState() {
+    this.fixedImages = "";
+    this.carouselImages = [];
+  }
+
+  setFixedImages(fixedImages) {
+    this.fixedImages = fixedImages;
+  }
+
+  setCarouselImages(carouselImages) {
+    this.carouselImages = carouselImages;
+  }
+
 }
 
 export default BannerContainer;

--- a/frontend/src/components/Banner/BannerContainer.js
+++ b/frontend/src/components/Banner/BannerContainer.js
@@ -24,9 +24,7 @@ class BannerContainer {
     this.resetState();
     
     API.get.bannerInfo().then((data) => {
-      this.setState({ 
-        fixedImage: data.event.imgurl
-      });
+      this.setState({ fixedImage: data.event.imgurl });
     });
   }
   

--- a/frontend/src/components/Banner/BannerPresentational.js
+++ b/frontend/src/components/Banner/BannerPresentational.js
@@ -28,7 +28,7 @@ class BannerPresentational {
           </div>
           <div class="contents right"> 
             <img src="http://shop4.daumcdn.net/shophow/sib/0_210219175151_tbehDsXzWnJKZNGWJxRuYhONIcINMfri" /> <!-- 임시 -->
-            <div id="banner-slide"></div>
+            <div id="banner-carousel"></div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/Banner/BannerPresentational.js
+++ b/frontend/src/components/Banner/BannerPresentational.js
@@ -3,12 +3,17 @@ import "./banner.scss";
 class BannerPresentational {
   constructor({ $target, ...props }) {
     this.$target = $target;
+    this.$Banner = document.createElement("div");
+    this.$Banner.className = "banner";
+    
+    // props
     this.imgSrc = props.fixedImage;
     
     this.init();
   }
 
   init() { 
+    this.$target.innerHTML = ""; // 먼저 타겟을 지우고 나서 렌더 진행
     this.render();
   }
   
@@ -27,8 +32,13 @@ class BannerPresentational {
           </div>
         </div>
       </div>
-    `
-    this.$target.insertAdjacentHTML('beforeend', $Banner);
+    `;
+    this.$Banner.insertAdjacentHTML('beforeend', $Banner); // string -> HTMLDOMElement
+    this.$target.appendChild(this.$Banner); // DOM -> DOM
+  }
+
+  reRender(){ 
+    this.$target.appendChild(this.$Banner); // DOM -> DOM
   }
 }
 

--- a/frontend/src/components/Banner/BannerPresentational.js
+++ b/frontend/src/components/Banner/BannerPresentational.js
@@ -2,18 +2,30 @@ import "./banner.scss";
 
 class BannerPresentational {
   constructor({ $target }) {
+    this.$target = $target;
 
+    this.init();
   }
 
   init() { 
     this.render();
 
-
   }
   
   render() {
     const $Banner = /* html */ `
-      <div class="">
+      <div class="container">
+        <div class="wrapper">
+          <div class="contents left"> 
+            <a href="#"> 
+              <img src="http://shop4.daumcdn.net/shophow/sib/0_210219175151_tbehDsXzWnJKZNGWJxRuYhONIcINMfri" />
+            </a>
+          </div>
+          <div class="contents right"> 
+            <img src="http://shop4.daumcdn.net/shophow/sib/0_210219175151_tbehDsXzWnJKZNGWJxRuYhONIcINMfri" />
+            <div id="banner-slide"> </div>
+          </div>
+        </div>
       </div>
     `
     this.$target.insertAdjacentHTML('beforeend', $Banner);

--- a/frontend/src/components/Banner/BannerPresentational.js
+++ b/frontend/src/components/Banner/BannerPresentational.js
@@ -1,15 +1,15 @@
 import "./banner.scss";
 
 class BannerPresentational {
-  constructor({ $target }) {
+  constructor({ $target, ...props }) {
     this.$target = $target;
-
+    this.imgSrc = props.fixedImage;
+    
     this.init();
   }
 
   init() { 
     this.render();
-
   }
   
   render() {
@@ -18,11 +18,11 @@ class BannerPresentational {
         <div class="wrapper">
           <div class="contents left"> 
             <a href="#"> 
-              <img src="http://shop4.daumcdn.net/shophow/sib/0_210219175151_tbehDsXzWnJKZNGWJxRuYhONIcINMfri" />
+              <img src=${this.imgSrc} />
             </a>
           </div>
           <div class="contents right"> 
-            <img src="http://shop4.daumcdn.net/shophow/sib/0_210219175151_tbehDsXzWnJKZNGWJxRuYhONIcINMfri" />
+            <img src="http://shop4.daumcdn.net/shophow/sib/0_210219175151_tbehDsXzWnJKZNGWJxRuYhONIcINMfri" /> <!-- 임시 -->
             <div id="banner-slide"> </div>
           </div>
         </div>

--- a/frontend/src/components/Banner/BannerPresentational.js
+++ b/frontend/src/components/Banner/BannerPresentational.js
@@ -1,0 +1,23 @@
+import "./banner.scss";
+
+class BannerPresentational {
+  constructor({ $target }) {
+
+  }
+
+  init() { 
+    this.render();
+
+
+  }
+  
+  render() {
+    const $Banner = /* html */ `
+      <div class="">
+      </div>
+    `
+    this.$target.insertAdjacentHTML('beforeend', $Banner);
+  }
+}
+
+export default BannerPresentational;

--- a/frontend/src/components/Banner/BannerPresentational.js
+++ b/frontend/src/components/Banner/BannerPresentational.js
@@ -18,12 +18,12 @@ class BannerPresentational {
         <div class="wrapper">
           <div class="contents left"> 
             <a href="#"> 
-              <img src=${this.imgSrc} />
+              <img src="${this.imgSrc}" />
             </a>
           </div>
           <div class="contents right"> 
             <img src="http://shop4.daumcdn.net/shophow/sib/0_210219175151_tbehDsXzWnJKZNGWJxRuYhONIcINMfri" /> <!-- 임시 -->
-            <div id="banner-slide"> </div>
+            <div id="banner-slide"></div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/Banner/banner.scss
+++ b/frontend/src/components/Banner/banner.scss
@@ -1,0 +1,22 @@
+.banner {
+  display: flex;
+  justify-content: center;
+  
+  .wrapper {
+    margin-top: 19px;
+    box-sizing: border-box;
+    border: 1px solid #e4e4e4; // 변수로 뺄 수 있을 듯
+    
+    // contents-flex-box
+    .contents {
+      // width: 485px;
+      // height: 340px;
+      
+      .left, .right {
+        width: 100%;
+        display: flex;
+      }
+    }
+    
+  }
+}

--- a/frontend/src/components/Carousel/CarouselContainer.js
+++ b/frontend/src/components/Carousel/CarouselContainer.js
@@ -55,6 +55,10 @@ class CarouselContainer {
     }
     this.images = images;
   }
+
+  // render() {
+  //   this.$target.append
+  // }
 }
 
 export default CarouselContainer;

--- a/frontend/src/components/Carousel/CarouselContainer.js
+++ b/frontend/src/components/Carousel/CarouselContainer.js
@@ -36,11 +36,11 @@ class CarouselContainer {
     switch (type) {
       case "banner":
         this.type = type;
-        this.$carousel = new BannerCarouselPresentational({ $target });
+        this.$carousel = new BannerCarouselPresentational({ $target, images: this.images });
         break;
       case "hotTheme":
         this.type = type;
-        this.$carousel = new HotThemeCarouselPresentational({ $target });
+        this.$carousel = new HotThemeCarouselPresentational({ $target, images: this.images });
         break;
       default:
         console.error("Wrong type was inserted. Please check carousel assign syntax.")

--- a/frontend/src/components/Carousel/CarouselContainer.js
+++ b/frontend/src/components/Carousel/CarouselContainer.js
@@ -1,0 +1,60 @@
+import { BannerCarouselPresentational, HotThemeCarouselPresentational } from './CarouselPresentational.js'
+
+class CarouselContainer {
+  constructor({ $target }) {
+    this.$target = $target;
+    this.$carousel = null;
+    this.type = null;
+    this.images = [];
+  }
+
+  init({ type, images }) {
+    this.setState({type, images});
+  }
+  
+  setState({type, images}) {
+    if (this.type !== null || this.images.length !== 0 ) {
+      this.resetState();  
+    }
+    this.setType(type);
+    this.setImages(images);
+  }
+
+  resetState() {
+    this.type = null;
+    this.images = [];
+    this.$carousel?.remove(); // 혹시모르는 에러를 방지하기 위함.
+  }
+  
+  setType(type) {
+    if (this.type !== null) {
+      console.warn("carousel type was already declared !");
+      return;
+    }
+    
+    const $target = this.$target;
+    switch (type) {
+      case "banner":
+        this.type = type;
+        this.$carousel = new BannerCarouselPresentational({ $target });
+        break;
+      case "hotTheme":
+        this.type = type;
+        this.$carousel = new HotThemeCarouselPresentational({ $target });
+        break;
+      default:
+        console.error("Wrong type was inserted. Please check carousel assign syntax.")
+        break;
+    }
+  }
+
+  setImages(images) {
+    if (this.images !== null) {
+      console.warn("carousel images was already declared !");
+      return;
+    }
+    this.images = images;
+  }
+}
+
+export default CarouselContainer;

--- a/frontend/src/components/Carousel/CarouselPresentational.js
+++ b/frontend/src/components/Carousel/CarouselPresentational.js
@@ -1,3 +1,5 @@
+import './carousel.scss';
+
 // 부모 클래스
 class CarouselPresentational {
   constructor({ $target, images }) {

--- a/frontend/src/components/Carousel/CarouselPresentational.js
+++ b/frontend/src/components/Carousel/CarouselPresentational.js
@@ -1,9 +1,19 @@
-
 // 부모 클래스
 class CarouselPresentational {
-  constructor({ $target }) {
-
+  constructor({ $target, images }) {
+    this.$target = $target;
+    this.images = images;
   }
 }
 
-export default CarouselPresentational;
+export class BannerCarouselPresentational extends CarouselPresentational {
+  constructor({ $target, images }) {
+    super({ $target, images });
+  }
+} 
+
+export class HotThemeCarouselPresentational extends CarouselPresentational {
+  constructor() {
+    super({ $target, images });  
+  }
+}

--- a/frontend/src/components/Carousel/CarouselPresentational.js
+++ b/frontend/src/components/Carousel/CarouselPresentational.js
@@ -1,0 +1,9 @@
+
+// 부모 클래스
+class CarouselPresentational {
+  constructor({ $target }) {
+
+  }
+}
+
+export default CarouselPresentational;

--- a/frontend/src/components/Header/HeaderPresentational.js
+++ b/frontend/src/components/Header/HeaderPresentational.js
@@ -11,6 +11,10 @@ class HeaderPresentational {
   }
   init() {
     this.render();
+    
+    // 롤링 키워드 initialize
+    let $target = this.$target.querySelector("#rolling-keywords");
+    this.rollingKeywords = new RollingKeywordsContainer({ $target });
   }
   render() {
     const $Header = /* html */ `
@@ -57,10 +61,6 @@ class HeaderPresentational {
       </header>
     `
     this.$target.insertAdjacentHTML('beforeend', $Header);
-    
-    // 롤링 키워드 initialize
-    let $target = this.$target.querySelector("#rolling-keywords");
-    this.rollingKeywords = new RollingKeywordsContainer({ $target });
   }
 }
 

--- a/frontend/src/util/api.js
+++ b/frontend/src/util/api.js
@@ -1,5 +1,22 @@
+const END_POINT = "http://localhost:3333/api";
+
 const API = {
-  get:{}
+  get: {
+    bannerInfo() {
+      const result = fetch(`${END_POINT}/planning-events`)
+        .then((response) => {
+          return response.json();
+        })
+        .then((serializedData) => {
+          // console.log(JSON.stringify(serializedData));
+          return serializedData;
+          // return serializedData;
+          // return JSON.stringify(serializedData);
+        });
+        
+      return result;
+    }
+  }
 }
 
 export default API;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --mode development  --config ./frontend/webpack.config.js",
     "dev": "webpack serve --config ./frontend/webpack.config.js",
-    "start": "concurrently \"node backend/index.js\" \"node frontend/public/index.js\""
+    "start": "concurrently \"node backend/index.js\" \"webpack serve --config ./frontend/webpack.config.js\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- 4일차 작업에 대한 PR입니다.
  - 미션 구현보다 보다 SPA 다운 프로젝트 구조에 집중해서 짠 것 같습니다. 우선 PR을 올려놓고 나머지는 구현에 집중할 생각입니다.
  - 크롱께서 시도해보라고 하셨던 캐싱의 구현이 올바른 형태인지 잘 모르겠습니다. 배너에 대해 적용해서 테스트를 해봤는데, 구현 논리상 reRender라는 요상한 함수가 나타나서 이에 대한 리팩토링에 대해 고민이 많습니다.
  - reRender를 만든 이유는 render() 함수를 부르는 로직이 생각보다 복잡해져서인데, 이 부분은 분명 고민이 필요한 것 같습니다.
---
## Todos

### 작업 환경 todo list
- [x] 작업 환경 세팅
  - [x] 백엔드 express 기반
  - [x] 프론트엔드 webpack 기반 번들링
    - 리뷰어 님께서 말씀하셨던 express-webpack 서버 관련해서는 시간 안에 개선이 어려울 것으로 판단, 현재 환경에서 계속 진행할 생각입니다.
- [x] github 관리 전략
  - 현재의 브랜치는 다음과 같이 관리되고 있습니다. 
  ```
    ppamppam
    ㄴ dev
       ㄴ setup(/backendEnv | /frontendEnv)
       ㄴ feature(/컴포넌트이름_presentational | /컴포넌트이름_container)
  ```
컴포넌트 간 연관된 작업들이 있어서 feature/컴포넌트 정책은 다소 예외가 존재합니다.
모든 작업은 우선 origin dev을 기준으로 머지가 되고 PR 직전 ppamppam에 머지가 됩니다.
이후 upstream ppamppam으로 origin ppamppam이 PR을 보냅니다.

### 백엔드 todo list
- [ ] fetch()를 위한 백엔드 request, response의 구현 
  - [x] 단순 GET 요청
  - [ ] 요구사항의 페이지네이션 작업

### 프론트 엔드 todo list
- [x] 컴포넌트 구조 presentaional - container 패턴을 활용한 기초 설정
  - app과 Header에 구현된 것을 바탕으로 하여 같은 패턴으로 구현 하고자 합니다.
- [ ] 퍼블리싱 
  - 현재 스켈레톤 코드 작업중에 있습니다. 
  - [ ] 헤더 (롤링 키워드)
  - [x] 배너 (캐로슬)
  - [ ] 더보기 아이템
  - [ ] 하단 캐로슬
- [ ] API fetch
  - [ ] 헤더 롤링키워드
  - [x] 배너 아이템
  - [ ] 더보기 아이템
  - [ ] 하단 캐로슬